### PR TITLE
Added mypy and fixed square bracket splitting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,9 @@ repos:
         args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v1.9.0'  # Use the sha / tag you want to point at
+    hooks:
+    -   id: mypy
+        additional_dependencies: ["types-requests"]
+        exclude: "test_script.py"

--- a/README.md
+++ b/README.md
@@ -24,9 +24,13 @@ For example if you want to find all the zonal (`uo`) and meridonal (`vo`) veloci
 ```python
 from pangeo_forge_esgf.parsing import parse_instance_ids
 parse_iids = [
-    "CMIP6.PMIP.*.*.lgm.*.*.uo.*.*",
-    "CMIP6.PMIP.*.*.lgm.*.*.vo.*.*",
+    "CMIP6.PMIP.*.*.lgm.*.*.[uo, vo].*.*",
 ]
+# Comma separated values in square brackets will be expanded and the above is equivalent to:
+# parse_iids = [
+#     "CMIP6.PMIP.*.*.lgm.*.*.[uo, vo].*.*", # this is equivalent to passing
+#     "CMIP6.PMIP.*.*.lgm.*.*.vo.*.*",
+# ]
 iids = []
 for piid in parse_iids:
     iids.extend(parse_instance_ids(piid))

--- a/pangeo_forge_esgf/tests/test_parsing.py
+++ b/pangeo_forge_esgf/tests/test_parsing.py
@@ -1,11 +1,11 @@
 from pangeo_forge_esgf.parsing import parse_instance_ids
+import pytest
 
 
 def test_readme_example():
     # This is possibly flaky (due to the dependence on the ESGF API)
     parse_iids = [
-        "CMIP6.PMIP.*.*.lgm.*.*.uo.*.*",
-        "CMIP6.PMIP.*.*.lgm.*.*.vo.*.*",
+        "CMIP6.PMIP.*.*.lgm.*.*.[uo,vo].*.*",
     ]
     iids = []
     for piid in parse_iids:
@@ -29,3 +29,18 @@ def test_readme_example():
 
     for iid in expected_iids:
         assert iid in iids
+
+
+@pytest.mark.parametrize(
+    "facet_iid, expected",
+    [
+        ("a.b.c.d", ["a.b.c.d"]),
+        ("a.[b1, b2].c.[d1, d2]", ["a.b1.c.d1", "a.b1.c.d2", "a.b2.c.d1", "a.b2.c.d2"]),
+        ("a.[b1, b2].c.d", ["a.b1.c.d", "a.b2.c.d"]),
+        ("a.b.c.[d1, d2]", ["a.b.c.d1", "a.b.c.d2"]),
+    ],
+)
+def test_split_square_brackets(facet_iid, expected):
+    from pangeo_forge_esgf.parsing import split_square_brackets
+
+    assert split_square_brackets(facet_iid) == expected

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ test = [
 dev = [
     "ruff",
     "mypy",
+    "types-requests",
     "pre-commit",
     "pangeo-forge-esgf[test]"
 ]


### PR DESCRIPTION
I added mypy to the pre-commit linting and promptly found an issue with the code (nice!). This led to a fix for the (I think previously broken `extension` of facet values in square_brackets. 

This extension is quite nice for users who want a subset of values for a specific facet (e.g. variables). 