### PR TITLE
Further fixes to the release action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,6 +39,8 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install -e  ".[test]"
+      - name: 🔎 Check current version
+        run: python -c "import pangeo_forge_esgf; print(pangeo_forge_esgf.__version__)"
       - name: 🏄‍♂️ Run Tests
         shell: bash -l {0}
         run: |

--- a/.github/workflows/pythonpublish.yaml
+++ b/.github/workflows/pythonpublish.yaml
@@ -20,6 +20,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install setuptools setuptools-scm[toml] wheel twine
+          python -m pip install .
       - name: Check python version
         run: |
           python --version


### PR DESCRIPTION
The release action is still [failing due to missing dependencies](https://github.com/jbusecke/pangeo-forge-esgf/actions/runs/8527930061).
This change installs the package locally, which should resolve the dependencies properly.