### PR TITLE
Multi-node parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ test_refactor.ipynb
 test_refactor.py
 test_script copy.py
 pangeo_forge_esgf/recipe_inputs_old.py
+.vscode/settings.json

--- a/pangeo_forge_esgf/parsing.py
+++ b/pangeo_forge_esgf/parsing.py
@@ -1,4 +1,5 @@
 import requests
+import warnings
 from typing import Optional, List
 
 from .utils import facets_from_iid
@@ -48,9 +49,21 @@ def split_square_brackets(facet_string: str) -> List[str]:
 
 
 def parse_instance_ids(
-    iid_string: str, search_nodes: Optional[list[str]] = None
+    iid_string: str,
+    search_nodes: Optional[list[str]] = None,
+    search_node: Optional[str] = None,
 ) -> list[str]:
     """Parse an instance id with wildcards"""
+    if search_node is not None:
+        warnings.warn(
+            "`search_node` is being deprecated. Please provide a list of urls to `search_nodes` instead", 
+            DeprecationWarning
+        )
+        # make this backwards compatible
+        if search_nodes is None:
+            search_nodes = [search_node]
+
+    
     # I am never sure where to get the full list of SOLR indicies, took this from intake-esgf: https://intake-esgf.readthedocs.io/en/latest/configure.html
     if search_nodes is None:
         search_nodes = [

--- a/pangeo_forge_esgf/parsing.py
+++ b/pangeo_forge_esgf/parsing.py
@@ -47,27 +47,35 @@ def split_square_brackets(facet_string: str) -> List[str]:
     return split_iid_combinations
 
 
-def parse_instance_ids(iid_string: str, search_node: Optional[str] = None) -> list[str]:
+def parse_instance_ids(iid_string: str, search_nodes: Optional[list[str]] = None) -> list[str]:
     """Parse an instance id with wildcards"""
-    if search_node is None:
-        # search_node = "https://esgf-node.llnl.gov/esg-search/search"
-        search_node = "https://esgf-data.dkrz.de/esg-search/search"
-        # FIXME: I got some really weird flakyness with the LLNL node. This is a dumb way to test this...
-
+    # I am never sure where to get the full list of SOLR indicies, took this from intake-esgf: https://intake-esgf.readthedocs.io/en/latest/configure.html
+    if search_nodes is None:
+        search_nodes = [
+            "https://esgf-node.llnl.gov/esg-search/search",
+            "https://esgf-data.dkrz.de/esg-search/search",
+            "https://esgf.nci.org.au/esg-search/search",
+            "https://esgf-node.ornl.gov/esg-search/search",
+            "https://esgf-node.ipsl.upmc.fr/esg-search/search",
+            "https://esg-dn1.nsc.liu.se/esg-search/search",
+            "https://esgf.ceda.ac.uk/esg-search/search",
+        ]
+        
     # first resolve the square brackets
     split_iids: List[str] = split_square_brackets(iid_string)
 
     parsed_iids: List[str] = []
     for iid in split_iids:
-        facets = facets_from_iid(iid)
-        facets_filtered = {
-            k: v for k, v in facets.items() if v != "*"
-        }  # leaving out the wildcards here will just request everything for that facet
-
-        resp = request_from_facets(search_node, **facets_filtered)
-        if resp.status_code != 200:
-            print(f"Request [{resp.url}] failed with {resp.status_code}")
-        else:
-            json_dict = resp.json()
-            parsed_iids.extend(instance_ids_from_request(json_dict))
-    return parsed_iids
+        for node in search_nodes:
+            facets = facets_from_iid(iid)
+            facets_filtered = {
+                k: v for k, v in facets.items() if v != "*"
+            }  # leaving out the wildcards here will just request everything for that facet
+    
+            resp = request_from_facets(search_node, **facets_filtered)
+            if resp.status_code != 200:
+                print(f"Request [{resp.url}] failed with {resp.status_code}")
+            else:
+                json_dict = resp.json()
+                parsed_iids.extend(instance_ids_from_request(json_dict))
+    return list(set(parsed_iids))

--- a/pangeo_forge_esgf/parsing.py
+++ b/pangeo_forge_esgf/parsing.py
@@ -47,7 +47,9 @@ def split_square_brackets(facet_string: str) -> List[str]:
     return split_iid_combinations
 
 
-def parse_instance_ids(iid_string: str, search_nodes: Optional[list[str]] = None) -> list[str]:
+def parse_instance_ids(
+    iid_string: str, search_nodes: Optional[list[str]] = None
+) -> list[str]:
     """Parse an instance id with wildcards"""
     # I am never sure where to get the full list of SOLR indicies, took this from intake-esgf: https://intake-esgf.readthedocs.io/en/latest/configure.html
     if search_nodes is None:
@@ -60,7 +62,7 @@ def parse_instance_ids(iid_string: str, search_nodes: Optional[list[str]] = None
             "https://esg-dn1.nsc.liu.se/esg-search/search",
             "https://esgf.ceda.ac.uk/esg-search/search",
         ]
-        
+
     # first resolve the square brackets
     split_iids: List[str] = split_square_brackets(iid_string)
 
@@ -71,7 +73,7 @@ def parse_instance_ids(iid_string: str, search_nodes: Optional[list[str]] = None
             facets_filtered = {
                 k: v for k, v in facets.items() if v != "*"
             }  # leaving out the wildcards here will just request everything for that facet
-    
+
             resp = request_from_facets(search_node, **facets_filtered)
             if resp.status_code != 200:
                 print(f"Request [{resp.url}] failed with {resp.status_code}")

--- a/pangeo_forge_esgf/parsing.py
+++ b/pangeo_forge_esgf/parsing.py
@@ -87,7 +87,7 @@ def parse_instance_ids(
                 k: v for k, v in facets.items() if v != "*"
             }  # leaving out the wildcards here will just request everything for that facet
 
-            resp = request_from_facets(search_node, **facets_filtered)
+            resp = request_from_facets(node, **facets_filtered)
             if resp.status_code != 200:
                 print(f"Request [{resp.url}] failed with {resp.status_code}")
             else:

--- a/pangeo_forge_esgf/parsing.py
+++ b/pangeo_forge_esgf/parsing.py
@@ -81,6 +81,7 @@ def parse_instance_ids(
     parsed_iids: List[str] = []
     for iid in split_iids:
         for node in search_nodes:
+            print(f"{node=}")
             facets = facets_from_iid(iid)
             facets_filtered = {
                 k: v for k, v in facets.items() if v != "*"

--- a/pangeo_forge_esgf/parsing.py
+++ b/pangeo_forge_esgf/parsing.py
@@ -56,14 +56,13 @@ def parse_instance_ids(
     """Parse an instance id with wildcards"""
     if search_node is not None:
         warnings.warn(
-            "`search_node` is being deprecated. Please provide a list of urls to `search_nodes` instead", 
-            DeprecationWarning
+            "`search_node` is being deprecated. Please provide a list of urls to `search_nodes` instead",
+            DeprecationWarning,
         )
         # make this backwards compatible
         if search_nodes is None:
             search_nodes = [search_node]
 
-    
     # I am never sure where to get the full list of SOLR indicies, took this from intake-esgf: https://intake-esgf.readthedocs.io/en/latest/configure.html
     if search_nodes is None:
         search_nodes = [

--- a/pangeo_forge_esgf/tests/test_parsing.py
+++ b/pangeo_forge_esgf/tests/test_parsing.py
@@ -2,14 +2,30 @@ from pangeo_forge_esgf.parsing import parse_instance_ids
 import pytest
 
 
-def test_readme_example():
+def test_unparsable_iid():
+    parse_iids = [
+        "Some.random.*.*.crap.*.that.we.[cannot, will_not].parse",
+    ]
+    iids = []
+    for piid in parse_iids:
+        with pytest.warns(UserWarning):
+            iids.extend(parse_instance_ids(piid))
+    iids
+
+    assert len(iids) == 0
+
+
+@pytest.mark.parametrize(
+    "search_nodes", [None, ["https://esgf-node.llnl.gov/esg-search/search"]]
+)
+def test_readme_example(search_nodes):
     # This is possibly flaky (due to the dependence on the ESGF API)
     parse_iids = [
         "CMIP6.PMIP.*.*.lgm.*.*.[uo,vo].*.*",
     ]
     iids = []
     for piid in parse_iids:
-        iids.extend(parse_instance_ids(piid))
+        iids.extend(parse_instance_ids(piid, search_nodes))
     iids
 
     # I expect at least these iids to be parsed
@@ -29,6 +45,14 @@ def test_readme_example():
 
     for iid in expected_iids:
         assert iid in iids
+
+
+def test_deprecation_warning():
+    iid = ["CMIP6.PMIP.*.*.lgm.*.*.uo.*.*"]
+    with pytest.warns(DeprecationWarning):
+        parse_instance_ids(
+            iid[0], search_node="https://esgf-node.llnl.gov/esg-search/search"
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
A follow up to #21

`pangeo-forge-esgf.parsing.parse_instance_ids` now searches and combines over multiple search nodes. 

The input argument `search_node` is being deprecated and I added `search_nodes` to indicate the change.

Added some more tests and now raise a warning for iids that were not 'parseable' (returned nothing from ESGF).