### PR TITLE
Only warn if iids were not parsed

### DIFF
--- a/pangeo_forge_esgf/parsing.py
+++ b/pangeo_forge_esgf/parsing.py
@@ -105,6 +105,6 @@ def parse_instance_ids(
     parsed_iids = list(set(parsed_iids))
     no_result_iids = list(set(no_result_iids) - set(parsed_iids))
 
-    if len(no_results_iids) > 0:
+    if len(no_result_iids) > 0:
         warnings.warn(f"No parsed results for {no_result_iids=}", UserWarning)
     return parsed_iids

--- a/pangeo_forge_esgf/parsing.py
+++ b/pangeo_forge_esgf/parsing.py
@@ -99,6 +99,6 @@ def parse_instance_ids(
                         parsed_iids.extend(iids_from_request)
             except Exception as e:
                 print(f"Request for {iid=} to {node=} failed with {e}")
-    if len(no_results_iids)>0:
+    if len(no_results_iids) > 0:
         warnings.warn(f"No parsed results for {no_result_iids=}", UserWarning)
     return list(set(parsed_iids))

--- a/pangeo_forge_esgf/parsing.py
+++ b/pangeo_forge_esgf/parsing.py
@@ -99,12 +99,12 @@ def parse_instance_ids(
                         parsed_iids.extend(iids_from_request)
             except Exception as e:
                 print(f"Request for {iid=} to {node=} failed with {e}")
-    # there is the possibility that an iid is parsed by one node, but not another. 
+    # there is the possibility that an iid is parsed by one node, but not another.
     # TODO: Print some more helpful info per node if needed?
     # For now lets just make sure that no_result_iids only shows cases that fail on *every* node
     parsed_iids = list(set(parsed_iids))
     no_result_iids = list(set(no_result_iids) - set(parsed_iids))
-    
+
     if len(no_results_iids) > 0:
         warnings.warn(f"No parsed results for {no_result_iids=}", UserWarning)
     return parsed_iids

--- a/pangeo_forge_esgf/parsing.py
+++ b/pangeo_forge_esgf/parsing.py
@@ -82,7 +82,6 @@ def parse_instance_ids(
     no_result_iids: List[str] = []
     for iid in split_iids:
         for node in search_nodes:
-            print(f"{node=}")
             facets = facets_from_iid(iid)
             facets_filtered = {
                 k: v for k, v in facets.items() if v != "*"
@@ -100,5 +99,6 @@ def parse_instance_ids(
                         parsed_iids.extend(iids_from_request)
             except Exception as e:
                 print(f"Request for {iid=} to {node=} failed with {e}")
-    warnings.warn(f"No parsed results for {no_result_iids=}", UserWarning)
+    if len(no_results_iids)>0:
+        warnings.warn(f"No parsed results for {no_result_iids=}", UserWarning)
     return list(set(parsed_iids))

--- a/pangeo_forge_esgf/parsing.py
+++ b/pangeo_forge_esgf/parsing.py
@@ -99,6 +99,12 @@ def parse_instance_ids(
                         parsed_iids.extend(iids_from_request)
             except Exception as e:
                 print(f"Request for {iid=} to {node=} failed with {e}")
+    # there is the possibility that an iid is parsed by one node, but not another. 
+    # TODO: Print some more helpful info per node if needed?
+    # For now lets just make sure that no_result_iids only shows cases that fail on *every* node
+    parsed_iids = list(set(parsed_iids))
+    no_result_iids = list(set(no_result_iids) - set(parsed_iids))
+    
     if len(no_results_iids) > 0:
         warnings.warn(f"No parsed results for {no_result_iids=}", UserWarning)
-    return list(set(parsed_iids))
+    return parsed_iids


### PR DESCRIPTION
Small follow up fixes for #39

- Only warn if unparsable iids are actually present
- remove node print in loop