### PR TITLE
New API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,28 +13,27 @@ If you want all the required dependencies for testing and development simply do:
 pip install pangeo-forge-esgf[dev]
 ```
 
-## Parsing a list of instance ids using wildcards
+## Parsing a list of instance ids using wildcards and subsets of facets
 
 Pangeo forge recipes require the user to provide exact instance_id's for the datasets they want to be processed. Discovering these with the [web search](https://esgf-node.llnl.gov/search/cmip6/) can become cumbersome, especially when dealing with a large number of members/models etc.
 
-`pangeo-forge-esgf` provides some functions to query the ESGF API based on instance_id values with wildcards.
+`pangeo-forge-esgf` provides some functions to query the ESGF API based on instance_id values with wildcards and facet subsets in square brackets.
 
-For example if you want to find all the zonal (`uo`) and meridonal (`vo`) velocities available for the `lgm` experiment of PMIP, you can do:
+For example if you want to find all the zonal (`uo`) and meridonal (`vo`) velocities available for the `lgm` experiment of PMIP, with no restriction on `experiment_id`/`source_id` and other facets, you can do:
 
 ```python
 from pangeo_forge_esgf.parsing import parse_instance_ids
+from pangeo_forge_esgf.client import ESGFClient
+client = ESGFClient("https://esgf-node.llnl.gov/") # you can use other ESGF search nodes here too!
 parse_iids = [
     "CMIP6.PMIP.*.*.lgm.*.*.[uo, vo].*.*",
 ]
 # Comma separated values in square brackets will be expanded and the above is equivalent to:
 # parse_iids = [
-#     "CMIP6.PMIP.*.*.lgm.*.*.[uo, vo].*.*", # this is equivalent to passing
+#     "CMIP6.PMIP.*.*.lgm.*.*.uo.*.*",
 #     "CMIP6.PMIP.*.*.lgm.*.*.vo.*.*",
 # ]
-iids = []
-for piid in parse_iids:
-    iids.extend(parse_instance_ids(piid))
-iids
+iids = client.expand_instance_id_list(parse_iids)
 ```
 
 and you will get:

--- a/pangeo_forge_esgf/client.py
+++ b/pangeo_forge_esgf/client.py
@@ -1,0 +1,271 @@
+import requests
+import os
+from typing import Any, Union
+from dataclasses import dataclass
+from pangeo_forge_esgf.utils import facets_from_iid, split_square_brackets
+from collections import defaultdict
+
+
+# Python client for a SOLR ESGF search API
+@dataclass
+class ESGFClient:
+    base_url: str = "https://esgf-node.llnl.gov/"
+    distributed: bool = True
+    retracted: bool = False
+    format: str = "application/solr+json"
+    latest: bool = True
+
+    def __post_init__(self):
+        if "search" in self.base_url:
+            raise ValueError(
+                "Please provide the base URL of the ESGF search API, without `.../esg-search/search`."
+            )
+        self.url = os.path.join(self.base_url, "esg-search/search")
+
+    def _paginated_request(self, **params):
+        """Yields paginated responses using the ESGF REST API."""
+        offset = params.get("offset", 0)
+        limit = params.get("limit", 50)
+        total = offset + limit + 1
+        while (offset + limit) < total:
+            response = requests.get(self.url, params=params)
+            response.raise_for_status()
+            response = response.json()
+            yield response
+            limit = len(response["response"]["docs"])
+            total = response["response"]["numFound"]
+            offset = response["response"]["start"]
+            params["offset"] = offset + limit
+
+    def _search_datasets(self, **facets):
+        """Dataset level search"""
+        params = {
+            "type": "Dataset",
+            "retracted": str(self.retracted).lower(),
+            "format": self.format,
+            "latest": str(self.latest).lower(),
+            "distrib": str(self.distributed).lower(),
+        }
+        params.update(facets)
+        self._dataset_results = self._paginated_request(**params)
+
+    def _search_files_from_dataset_ids(self, dataset_ids: list[str]):
+        """Search files from dataset ids. (dataset_id = instance_id|data_node)"""
+        # raise error if datasets_id is empty
+        if len(dataset_ids) == 0:
+            raise ValueError("No dataset_ids provided.")
+        params = {
+            "type": "File",
+            "retracted": str(self.retracted).lower(),
+            "format": self.format,
+            "latest": str(self.latest).lower(),
+            "distrib": str(self.distributed).lower(),
+            "dataset_id": dataset_ids,
+        }
+        self._file_results = self._paginated_request(**params)
+
+    def _get_response_fields(self, fields: list[str], type: str) -> list[dict]:
+        """Extract fields from the search results. This also materializes the generator."""
+        response_list = []
+        if type == "dataset":
+            response_data = self._dataset_results
+        elif type == "file":
+            response_data = self._file_results
+        else:
+            raise ValueError("Invalid type. Must be 'dataset' or 'file'.")
+
+        # Note that it seems to be necessary to include the instance_id field in the search results to get any response data
+        if "instance_id" not in fields:
+            fields.append("instance_id")
+        for response in response_data:
+            for r in response["response"]["docs"]:
+                response_list.append({field: r[field] for field in fields})
+        return response_list
+
+    def _get_unique_field_list(self, field: str, type: str) -> list[str]:
+        """return list of unique values for a field in the search results."""
+        return list(
+            set([f[field] for f in self._get_response_fields([field], type=type)])
+        )
+
+    def expand_instance_id_list(self, instance_id_list: list[str]) -> list[str]:
+        """Given a list of instance ids with wildcards and square brackets, return all instance ids that the ESGF API can resolve."""
+        search_iids = []
+        for iid in instance_id_list:
+            if "[" in iid:
+                search_iids.extend(split_square_brackets(iid))
+            else:
+                search_iids.append(iid)
+
+        # now make a request for each of these instance ids
+        valid_iid_list = []
+        for iid in search_iids:
+            facets = facets_from_iid(iid)
+            self._search_datasets(**facets)
+            valid_iid_list.extend(
+                self._get_unique_field_list("instance_id", type="dataset")
+            )
+        return valid_iid_list
+
+    def get_recipe_inputs_from_iid_list(
+        self, instance_id_list: list[str]
+    ) -> dict[str, dict[str, dict[str, Any]]]:
+        fields = [
+            "id",
+            "instance_id",
+            "data_node",
+            "title",
+            "checksum",
+            "checksum_type",
+            "url",
+        ]
+        dataset_ids = []
+        # TODO refactor to take iid list as top level api
+        for iid in instance_id_list:
+            facets = facets_from_iid(iid)
+            self._search_datasets(**facets)
+            dataset_ids_single = self._get_unique_field_list("id", type="dataset")
+            dataset_ids.extend(dataset_ids_single)
+        print(f"Searching files for {dataset_ids=}")
+        self._search_files_from_dataset_ids(dataset_ids)
+        print(f"Extracting fields {fields=}")
+        response = self._get_response_fields(fields, type="file")
+        formatted_response = self._format_file_response_for_recipe(response)
+        print(f"{formatted_response=}")
+        return self._prune_formatted_response(formatted_response)
+
+    def _format_file_response_for_recipe(
+        self, response: list[dict]
+    ) -> dict[str, dict[str, dict[str, Any]]]:
+        """Extract file information from search results.
+        Returns results as a nested dictionary
+        Dataset instance_id -> data_node -> filename -> file info
+
+        NOTE: We internally use the 'dataset instance_id' as the top level key, but there is a
+        file level instance_id here too. We split that up internally to ensure consistency.
+        """
+        formatted_response: dict[str, dict[str, dict[str, Any]]] = defaultdict(
+            lambda: defaultdict(dict)
+        )
+        for r in response:
+            instance_id, filename, data_node = sanitize_id(r)
+            formatted_response[instance_id][data_node][filename] = {
+                k: v
+                for k, v in r.items()
+                if k not in ["id", "instance_id", "data_node", "title"]
+            }
+        return formatted_response
+
+    def _prune_formatted_response(
+        self, formatted_response: dict[str, dict[str, dict[str, Any]]]
+    ) -> dict[str, dict[str, Any]]:
+        """Prune the formatted response:
+        - Find all filenames
+        - Remove data nodes that do not contain all filenames
+        - Pick data nodes based on preferred list
+        """
+        filenames: dict[str, list[str]] = {i: [] for i in formatted_response.keys()}
+        for instance_id, data_node_dict in formatted_response.items():
+            for data_node, file_dict in data_node_dict.items():
+                filenames[instance_id].extend(file_dict.keys())
+        filenames = {i: list(set(v)) for i, v in filenames.items()}
+
+        # find all data_node names and print
+        data_nodes: list[str] = []
+        for instance_id, data_node_dict in formatted_response.items():
+            data_nodes.extend(data_node_dict.keys())
+        data_nodes = list(set(data_nodes))
+
+        def get_http_url(urls: list[str]) -> Union[str, None]:
+            for url in urls:
+                url, app, protocol = url.split("|")
+                if protocol == "HTTPServer":
+                    return url
+            return None
+
+        # create a new nested dict that only contains a single http url
+        single_http_url_response: dict[str, dict[str, dict[str, Any]]] = defaultdict(
+            lambda: defaultdict(dict)
+        )
+
+        for instance_id, data_node_dict in formatted_response.items():
+            for data_node, file_dict in data_node_dict.items():
+                for f, fields in file_dict.items():
+                    http_url = get_http_url(fields["url"])
+                    if http_url is not None:
+                        insert_dict = {"url": http_url}
+                        # TODO: We might want to retain other fields here in addition to the checksum?
+                        for field in ["checksum", "checksum_type"]:
+                            insert_dict[field] = fields[field]
+                        single_http_url_response[instance_id][data_node][f] = (
+                            insert_dict
+                        )
+
+        pruned_data_nodes_response: dict[str, dict[str, dict[str, Any]]] = defaultdict(
+            lambda: defaultdict(dict)
+        )
+        # remove data nodes that do not contain all filenames
+        for instance_id, data_node_dict in single_http_url_response.items():
+            for data_node, file_dict in data_node_dict.items():
+                if all([f in file_dict.keys() for f in filenames[instance_id]]):
+                    pruned_data_nodes_response[instance_id][data_node] = file_dict
+
+        # list of preferred data nodes
+        preferred_data_nodes = [
+            "aims3.llnl.gov",
+            "esgf-data1.llnl.gov",
+            "esgf-data.ucar.edu",
+            "vesg.ipsl.upmc.fr",
+            "esgf.ceda.ac.uk",
+            "esgf3.dkrz.de",
+        ]
+
+        single_data_node_response: dict[str, dict[str, Any]] = defaultdict(dict)
+        for instance_id, data_node_dict in pruned_data_nodes_response.items():
+            for data_node in preferred_data_nodes:
+                if data_node in data_node_dict.keys():
+                    break
+            else:
+                # otherwise pick the first one
+                if len(data_node_dict) > 0:
+                    data_node = list(data_node_dict.keys())[0]
+            single_data_node_response[instance_id] = data_node_dict[data_node]
+
+        return single_data_node_response
+
+
+def sanitize_id(r: dict) -> tuple[str, str, str]:
+    """Sanitize the id field from the response to extract the instance_id, filename and data_node
+    # goddamn it, the 'id' field does not adhere to the schema for some datasets, so ill treat the values as the truth?
+    # So in some cases the id field includes the data_node in other not...great
+    # In some cases the instance_id includes the filename and in others not...this is infuriating!
+    # Ok ill assume that i can trust the data_node and 'title' output and will have to do some massaging to get the dataset
+    # instance_id
+    # Different cases I have experienced so far for the 'id' schema
+    # - <dataset_instance_id>.<filename>|<data_node>
+    # - <dataset_instance_id>.<filename>
+    # I wonder if that is specified somewhere
+    # Maybe also a reason to use the official esgf python client?
+    """
+    filename: str = r["title"]
+    data_node: str = r["data_node"]
+
+    # split the 'id' field into instance_id and data_node and filename
+    def maybe_split_id(id: str) -> str:
+        if "|" in r["id"]:
+            diid, dn = r["id"].split("|")
+            assert data_node == dn
+            return diid
+        else:
+            return r["id"]
+
+    def get_final_instance_id(dataset_instance_id: str, filename: str) -> str:
+        # make sure that the filename is not included
+        if filename in dataset_instance_id:
+            return dataset_instance_id.replace("." + filename, "")
+        else:
+            return dataset_instance_id
+
+    dataset_instance_id = maybe_split_id(r["id"])
+    final_instance_id = get_final_instance_id(dataset_instance_id, filename)
+    return final_instance_id, filename, data_node

--- a/pangeo_forge_esgf/parsing.py
+++ b/pangeo_forge_esgf/parsing.py
@@ -1,51 +1,6 @@
-import requests
 import warnings
-from typing import Optional, List
-
-from .utils import facets_from_iid
-
-
-def request_from_facets(url, **facets):
-    params = {
-        "type": "Dataset",
-        "retracted": "false",
-        "format": "application/solr+json",
-        "fields": "instance_id",
-        "latest": "true",
-        "distrib": "true",
-        "limit": 500,
-    }
-    params.update(facets)
-    return requests.get(url=url, params=params)
-
-
-def instance_ids_from_request(json_dict):
-    iids = [item["instance_id"] for item in json_dict["response"]["docs"]]
-    uniqe_iids = list(set(iids))
-    return uniqe_iids
-
-
-def split_square_brackets(facet_string: str) -> List[str]:
-    ## split a string like this `a.[b1, b2].c.[d1, d2]` into a list like this: ['a.b1.c.d1', 'a.b1.c.d2', 'a.b2.c.d1', 'a.b2.c.d2']
-    if "[" not in facet_string:
-        return [facet_string]
-
-    start_index = facet_string.find("[")
-    end_index = facet_string.find("]")
-    prefix = facet_string[:start_index]
-    suffix = facet_string[end_index + 1 :]
-
-    inner_parts = [
-        part.strip() for part in facet_string[start_index + 1 : end_index].split(",")
-    ]
-
-    split_iid_combinations = []
-    for part in inner_parts:
-        inner_combinations = split_square_brackets(part + suffix)
-        for inner_combination in inner_combinations:
-            split_iid_combinations.append(prefix + inner_combination)
-
-    return split_iid_combinations
+from typing import Optional
+from pangeo_forge_esgf.client import ESGFClient
 
 
 def parse_instance_ids(
@@ -54,6 +9,11 @@ def parse_instance_ids(
     search_node: Optional[str] = None,
 ) -> list[str]:
     """Parse an instance id with wildcards"""
+    warnings.warn(
+        "The parsing module will be deprecated soon. Please use the ESGFClient method `expand_instance_id_list` instead.",
+        DeprecationWarning,
+    )
+
     if search_node is not None:
         warnings.warn(
             "`search_node` is being deprecated. Please provide a list of urls to `search_nodes` instead",
@@ -64,47 +24,20 @@ def parse_instance_ids(
             search_nodes = [search_node]
 
     # I am never sure where to get the full list of SOLR indicies, took this from intake-esgf: https://intake-esgf.readthedocs.io/en/latest/configure.html
+    parsed_iids = []
     if search_nodes is None:
         search_nodes = [
-            "https://esgf-node.llnl.gov/esg-search/search",
-            "https://esgf-data.dkrz.de/esg-search/search",
-            "https://esgf.nci.org.au/esg-search/search",
-            "https://esgf-node.ornl.gov/esg-search/search",
-            "https://esgf-node.ipsl.upmc.fr/esg-search/search",
-            "https://esg-dn1.nsc.liu.se/esg-search/search",
-            "https://esgf.ceda.ac.uk/esg-search/search",
+            "https://esgf-node.llnl.gov",
+            "https://esgf-data.dkrz.de",
+            "https://esgf.nci.org.au",
+            "https://esgf-node.ornl.gov",
+            "https://esgf-node.ipsl.upmc.fr",
+            "https://esg-dn1.nsc.liu.se",
+            "https://esgf.ceda.ac.uk",
         ]
 
-    # first resolve the square brackets
-    split_iids: List[str] = split_square_brackets(iid_string)
+    for node in search_nodes:
+        client = ESGFClient(base_url=node)
+        parsed_iids.extend(client.expand_instance_id_list([iid_string]))
 
-    parsed_iids: List[str] = []
-    no_result_iids: List[str] = []
-    for iid in split_iids:
-        for node in search_nodes:
-            facets = facets_from_iid(iid)
-            facets_filtered = {
-                k: v for k, v in facets.items() if v != "*"
-            }  # leaving out the wildcards here will just request everything for that facet
-            try:
-                resp = request_from_facets(node, **facets_filtered)
-                if resp.status_code != 200:
-                    print(f"Request [{resp.url}] failed with {resp.status_code}")
-                else:
-                    json_dict = resp.json()
-                    iids_from_request = instance_ids_from_request(json_dict)
-                    if len(iids_from_request) == 0:
-                        no_result_iids.append(iid)
-                    else:
-                        parsed_iids.extend(iids_from_request)
-            except Exception as e:
-                print(f"Request for {iid=} to {node=} failed with {e}")
-    # there is the possibility that an iid is parsed by one node, but not another.
-    # TODO: Print some more helpful info per node if needed?
-    # For now lets just make sure that no_result_iids only shows cases that fail on *every* node
-    parsed_iids = list(set(parsed_iids))
-    no_result_iids = list(set(no_result_iids) - set(parsed_iids))
-
-    if len(no_result_iids) > 0:
-        warnings.warn(f"No parsed results for {no_result_iids=}", UserWarning)
     return parsed_iids

--- a/pangeo_forge_esgf/tests/test_client.py
+++ b/pangeo_forge_esgf/tests/test_client.py
@@ -1,0 +1,77 @@
+from pangeo_forge_esgf.client import ESGFClient
+import pytest
+
+
+class TestESGFClient:
+    def test_init(self):
+        client = ESGFClient()
+        assert client.base_url == "https://esgf-node.llnl.gov/"
+        assert client.url == "https://esgf-node.llnl.gov/esg-search/search"
+        assert client.distributed is True
+        assert client.retracted is False
+        assert client.format == "application/solr+json"
+        assert client.latest is True
+
+    def test_init_wrong_url(self):
+        with pytest.raises(ValueError):
+            ESGFClient(base_url="https://esgf-node.llnl.gov/esg-search/search")
+
+    def test_init_different_url(self):
+        client = ESGFClient(base_url="https://some-thing.gov")
+        assert client.url == "https://some-thing.gov/esg-search/search"
+
+    def test_url(self):
+        client = ESGFClient()
+        assert client.url == "https://esgf-node.llnl.gov/esg-search/search"
+
+
+def test_end_to_end():
+    client = ESGFClient()
+    raw_iids = [
+        "CMIP6.ScenarioMIP.NCAR.CESM2-WACCM.ssp245.r1i1p1f1.SImon.sifb.gn.v20190815",
+        "CMIP6.CMIP.IPSL.IPSL-CM6A-LR.historical.r8i1p1f1.Omon.zmeso.gn.v20180803",
+        "CMIP6.CMIP.IPSL.IPSL-CM6A-LR.historical.r24i1p1f1.SImon.sifb.gn.v20180803",
+        "CMIP6.ScenarioMIP.MPI-M.MPI-ESM1-2-LR.ssp585.r47i1p1f1.SImon.sifb.gn.v20190815",
+        "CMIP6.CMIP.MPI-M.MPI-ESM1-2-HR.historical.r1i1p1f1.3hr.pr.gn.v20190710",
+        "CMIP6.ScenarioMIP.IPSL.IPSL-CM6A-LR.ssp245.r3i1p1f1.Omon.zmeso.gn.v20191121",
+        "CMIP6.ScenarioMIP.MPI-M.MPI-ESM1-2-LR.ssp245.r43i1p1f1.SImon.sifb.gn.v20190815",
+        "CMIP6.CMIP.IPSL.IPSL-CM6A-LR.historical.r29i1p1f1.SImon.siitdthick.gn.v20180803",
+        # these did pass
+        "CMIP6.CMIP.THU.CIESM.historical.r3i1p1f1.Omon.tos.gn.v20200220",
+        "CMIP6.ScenarioMIP.EC-Earth-Consortium.EC-Earth3.ssp245.r15i1p1f2.day.pr.gr.v20201015",
+        "CMIP6.ScenarioMIP.EC-Earth-Consortium.EC-Earth3.ssp245.r111i1p1f1.day.psl.gr.v20210401",
+        "CMIP6.ScenarioMIP.MIROC.MIROC6.ssp585.r31i1p1f1.day.pr.gn.v20200623",
+        "CMIP6.CMIP.MIROC.MIROC6.historical.r37i1p1f1.day.pr.gn.v20200519",
+    ]
+    parsed_iids = client.expand_instance_id_list(raw_iids)
+    output = client.get_recipe_inputs_from_iid_list(parsed_iids)
+
+    # this might fail in the future (due to flakyness but its a nice test of https://github.com/jbusecke/pangeo-forge-esgf/issues/42)
+    assert set(output.keys()) == set(raw_iids)
+
+
+def test_readme_example():
+    # This is possibly flaky (due to the dependence on the ESGF API)
+    parse_iids = [
+        "CMIP6.PMIP.*.*.lgm.*.*.[uo,vo].*.*",
+    ]
+    client = ESGFClient("https://esgf-node.llnl.gov/")
+    iids = client.expand_instance_id_list(parse_iids)
+
+    # I expect at least these iids to be parsed
+    # (there might be new ones that are added at a later point)
+    expected_iids = [
+        "CMIP6.PMIP.MIROC.MIROC-ES2L.lgm.r1i1p1f2.Omon.uo.gn.v20191002",
+        "CMIP6.PMIP.AWI.AWI-ESM-1-1-LR.lgm.r1i1p1f1.Odec.uo.gn.v20200212",
+        "CMIP6.PMIP.AWI.AWI-ESM-1-1-LR.lgm.r1i1p1f1.Omon.uo.gn.v20200212",
+        "CMIP6.PMIP.MIROC.MIROC-ES2L.lgm.r1i1p1f2.Omon.uo.gr1.v20200911",
+        "CMIP6.PMIP.MPI-M.MPI-ESM1-2-LR.lgm.r1i1p1f1.Omon.uo.gn.v20200909",
+        "CMIP6.PMIP.AWI.AWI-ESM-1-1-LR.lgm.r1i1p1f1.Omon.vo.gn.v20200212",
+        "CMIP6.PMIP.MIROC.MIROC-ES2L.lgm.r1i1p1f2.Omon.vo.gn.v20191002",
+        "CMIP6.PMIP.AWI.AWI-ESM-1-1-LR.lgm.r1i1p1f1.Odec.vo.gn.v20200212",
+        "CMIP6.PMIP.MIROC.MIROC-ES2L.lgm.r1i1p1f2.Omon.vo.gr1.v20200911",
+        "CMIP6.PMIP.MPI-M.MPI-ESM1-2-LR.lgm.r1i1p1f1.Omon.vo.gn.v20190710",
+    ]
+
+    for iid in expected_iids:
+        assert iid in iids

--- a/pangeo_forge_esgf/tests/test_parsing.py
+++ b/pangeo_forge_esgf/tests/test_parsing.py
@@ -2,22 +2,7 @@ from pangeo_forge_esgf.parsing import parse_instance_ids
 import pytest
 
 
-def test_unparsable_iid():
-    parse_iids = [
-        "Some.random.*.*.crap.*.that.we.[cannot, will_not].parse",
-    ]
-    iids = []
-    for piid in parse_iids:
-        with pytest.warns(UserWarning):
-            iids.extend(parse_instance_ids(piid))
-    iids
-
-    assert len(iids) == 0
-
-
-@pytest.mark.parametrize(
-    "search_nodes", [None, ["https://esgf-node.llnl.gov/esg-search/search"]]
-)
+@pytest.mark.parametrize("search_nodes", [None, ["https://esgf-node.llnl.gov/"]])
 def test_readme_example(search_nodes):
     # This is possibly flaky (due to the dependence on the ESGF API)
     parse_iids = [
@@ -50,21 +35,4 @@ def test_readme_example(search_nodes):
 def test_deprecation_warning():
     iid = ["CMIP6.PMIP.*.*.lgm.*.*.uo.*.*"]
     with pytest.warns(DeprecationWarning):
-        parse_instance_ids(
-            iid[0], search_node="https://esgf-node.llnl.gov/esg-search/search"
-        )
-
-
-@pytest.mark.parametrize(
-    "facet_iid, expected",
-    [
-        ("a.b.c.d", ["a.b.c.d"]),
-        ("a.[b1, b2].c.[d1, d2]", ["a.b1.c.d1", "a.b1.c.d2", "a.b2.c.d1", "a.b2.c.d2"]),
-        ("a.[b1, b2].c.d", ["a.b1.c.d", "a.b2.c.d"]),
-        ("a.b.c.[d1, d2]", ["a.b.c.d1", "a.b.c.d2"]),
-    ],
-)
-def test_split_square_brackets(facet_iid, expected):
-    from pangeo_forge_esgf.parsing import split_square_brackets
-
-    assert split_square_brackets(facet_iid) == expected
+        parse_instance_ids(iid[0], search_node="https://esgf-node.llnl.gov")

--- a/pangeo_forge_esgf/tests/test_utils.py
+++ b/pangeo_forge_esgf/tests/test_utils.py
@@ -1,6 +1,10 @@
 import pytest
 import requests
-from pangeo_forge_esgf.utils import facets_from_iid, CMIP6_naming_schema
+from pangeo_forge_esgf.utils import (
+    facets_from_iid,
+    CMIP6_naming_schema,
+    split_square_brackets,
+)
 
 
 def get_official_drs_naming_scheme():
@@ -46,3 +50,16 @@ def test_facets_from_iid(fix_version):
                 assert k == "version"
         else:
             assert k == v
+
+
+@pytest.mark.parametrize(
+    "facet_iid, expected",
+    [
+        ("a.b.c.d", ["a.b.c.d"]),
+        ("a.[b1, b2].c.[d1, d2]", ["a.b1.c.d1", "a.b1.c.d2", "a.b2.c.d1", "a.b2.c.d2"]),
+        ("a.[b1, b2].c.d", ["a.b1.c.d", "a.b2.c.d"]),
+        ("a.b.c.[d1, d2]", ["a.b.c.d1", "a.b.c.d2"]),
+    ],
+)
+def test_split_square_brackets(facet_iid, expected):
+    assert split_square_brackets(facet_iid) == expected

--- a/pangeo_forge_esgf/utils.py
+++ b/pangeo_forge_esgf/utils.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, List
 
 CMIP6_naming_schema = "mip_era.activity_id.institution_id.source_id.experiment_id.member_id.table_id.variable_id.grid_label.version"
 
@@ -13,4 +13,30 @@ def facets_from_iid(iid: str, fix_version: bool = True) -> Dict[str, str]:
         facets[name] = value
     if fix_version:
         facets["version"] = facets["version"].replace("v", "")
+    facets = {
+        k: v for k, v in facets.items() if v != "*"
+    }  # leaving out the wildcards here will just request everything for that facet
     return facets
+
+
+def split_square_brackets(facet_string: str) -> List[str]:
+    ## split a string like this `a.[b1, b2].c.[d1, d2]` into a list like this: ['a.b1.c.d1', 'a.b1.c.d2', 'a.b2.c.d1', 'a.b2.c.d2']
+    if "[" not in facet_string:
+        return [facet_string]
+
+    start_index = facet_string.find("[")
+    end_index = facet_string.find("]")
+    prefix = facet_string[:start_index]
+    suffix = facet_string[end_index + 1 :]
+
+    inner_parts = [
+        part.strip() for part in facet_string[start_index + 1 : end_index].split(",")
+    ]
+
+    split_iid_combinations = []
+    for part in inner_parts:
+        inner_combinations = split_square_brackets(part + suffix)
+        for inner_combination in inner_combinations:
+            split_iid_combinations.append(prefix + inner_combination)
+
+    return split_iid_combinations


### PR DESCRIPTION
I have taken what I have learned from #42 and written a completely new logic to get info from the ESGF API. 
This one is a bunch simpler, not async, and seems to actually get a lot more URL information (tested with the cases in #42). 

Ill test drive this over at the CMIP6 feedstock and will then finish up over here. 

- [ ] Evaluate if at this point we could also use the official client?
- [ ] Remove the recipe_input module
- [ ] Make a loud announcement about the breaking changes
- [ ] Make sure to release a new major version after completing this. 