### PR TITLE
Raise error for badly formatted iid

### DIFF
--- a/pangeo_forge_esgf/tests/test_utils.py
+++ b/pangeo_forge_esgf/tests/test_utils.py
@@ -47,7 +47,8 @@ def test_facets_from_iid(fix_version):
         else:
             assert k == v
 
+
 def test_facets_from_iid_wrong_length():
-    iid = 'Just.three.facets'
+    iid = "Just.three.facets"
     with pytest.raises(ValueError):
         facets_from_iid(iid)

--- a/pangeo_forge_esgf/tests/test_utils.py
+++ b/pangeo_forge_esgf/tests/test_utils.py
@@ -46,3 +46,8 @@ def test_facets_from_iid(fix_version):
                 assert k == "version"
         else:
             assert k == v
+
+def test_facets_from_iid_wrong_length():
+    iid = 'Just.three.facets'
+    with pytest.raises(ValueError):
+        facets_from_iid(iid)

--- a/pangeo_forge_esgf/utils.py
+++ b/pangeo_forge_esgf/utils.py
@@ -11,7 +11,7 @@ def facets_from_iid(iid: str, fix_version: bool = True) -> Dict[str, str]:
     template_split = iid_name_template.split(".")
     iid_split = iid.split(".")
     if len(template_split) != len(iid_split):
-        raise ValueError(f"Found {len(iid_split)} facets in `iid`, but expected {len(template_split)}. Got {iid_split=}"
+        raise ValueError(f"Found {len(iid_split)} facets in `iid`, but expected {len(template_split)}. Got {iid_split=}")
     facets = {}
     for name, value in zip(template_split, iids_split):
         facets[name] = value

--- a/pangeo_forge_esgf/utils.py
+++ b/pangeo_forge_esgf/utils.py
@@ -15,7 +15,7 @@ def facets_from_iid(iid: str, fix_version: bool = True) -> Dict[str, str]:
             f"Found {len(iid_split)} facets in `iid`, but expected {len(template_split)}. Got {iid_split=}"
         )
     facets = {}
-    for name, value in zip(template_split, iids_split):
+    for name, value in zip(template_split, iid_split):
         facets[name] = value
     if fix_version:
         facets["version"] = facets["version"].replace("v", "")

--- a/pangeo_forge_esgf/utils.py
+++ b/pangeo_forge_esgf/utils.py
@@ -11,7 +11,9 @@ def facets_from_iid(iid: str, fix_version: bool = True) -> Dict[str, str]:
     template_split = iid_name_template.split(".")
     iid_split = iid.split(".")
     if len(template_split) != len(iid_split):
-        raise ValueError(f"Found {len(iid_split)} facets in `iid`, but expected {len(template_split)}. Got {iid_split=}")
+        raise ValueError(
+            f"Found {len(iid_split)} facets in `iid`, but expected {len(template_split)}. Got {iid_split=}"
+        )
     facets = {}
     for name, value in zip(template_split, iids_split):
         facets[name] = value

--- a/pangeo_forge_esgf/utils.py
+++ b/pangeo_forge_esgf/utils.py
@@ -8,8 +8,12 @@ def facets_from_iid(iid: str, fix_version: bool = True) -> Dict[str, str]:
     By default removes `v` from version
     """
     iid_name_template = CMIP6_naming_schema
+    template_split = iid_name_template.split(".")
+    iid_split = iid.split(".")
+    if len(template_split) != len(iid_split):
+        raise ValueError(f"Found {len(iid_split)} facets in `iid`, but expected {len(template_split)}. Got {iid_split=}"
     facets = {}
-    for name, value in zip(iid_name_template.split("."), iid.split(".")):
+    for name, value in zip(template_split, iids_split):
         facets[name] = value
     if fix_version:
         facets["version"] = facets["version"].replace("v", "")


### PR DESCRIPTION
Just found a case over in https://github.com/leap-stc/cmip6-leap-feedstock/pull/170/commits/c4509c65704e0854dec83df22cc14ea692b186a2 where I forgot to add a dot in the iid. 
The error raised was a key error for version, which makes sense but is not very intuitive. 

This PR implements tests+raisees an error that is easier to grok.